### PR TITLE
Support for dynamic heights and paddings

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
       .inner-wrapper {
         padding: 20px;
+        box-sizing: border-box;
       }
 
       .container {
@@ -29,8 +30,8 @@
       <div class="box">
         <button id="slideThing1">Slide Thing #1</button>
 
-        <div class="thing" id="thing1">
-          <div class="inner-wrapper">
+        <div class="thing inner-wrapper" id="thing1">
+          <div>
             <h1>My First Heading</h1>
             <p>My first paragraph.</p>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "slide-element",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-typescript": "^7.15.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ type Options = KeyframeAnimationOptions & {
   duration?: number;
   easing?: string;
   display?: string;
+  cache?: string;
 };
 
 type SlideMethods = {
@@ -17,8 +18,9 @@ type SlideMethods = {
 let defaultOptions = {
   easing: "ease",
   duration: 250,
-  fill: "forwards",
+  fill: "backwards",
   display: "block",
+  cache: true,
 };
 
 let SlideController = (
@@ -41,7 +43,8 @@ let SlideController = (
 
   let expandedHeight = (() => {
     // We have the expanded height already cached from before, so use that.
-    if (getCachedHeight()) return getCachedHeight();
+    if (getCachedHeight() && (mergedOptions.cache as string))
+      return getCachedHeight();
 
     // The element is already visible, so grab the height.
     if (getHeight()) {
@@ -62,8 +65,17 @@ let SlideController = (
 
     let frames = [getHeight(true), lowerBound].map((height) => ({
       height,
+      paddingTop: 0,
+      paddingBottom: 0,
       overflow: "hidden",
     }));
+
+    frames[0].paddingTop = window
+      .getComputedStyle(element)
+      .getPropertyValue("padding-top");
+    frames[0].paddingBottom = window
+      .getComputedStyle(element)
+      .getPropertyValue("padding-bottom");
 
     if (willOpen) {
       frames[0].height = expandedHeight;


### PR DESCRIPTION
# Description of Proposed Changes
Hey @alexmacarthur I've resolved the problems when height is dynamicly changed, I've changed `fill` from `forwards` to `backwards`, this way the style properties will reset upon animation, so there are no more problems with height. Also added new option `cache`, if someone expect the height to change in the future it should be disabled. To be honest caching the height isn't the best approach, height can change anytime, eg. responsive design. Maybe you should reconsider if not to remove the caching instead?

I've also resolved the gotha with the padding as bonus https://github.com/alexmacarthur/slide-element#gotchas but the `box-sizing: border-box` must be use for this to work.

# Related Issue (if applicable)
#19 

# Testing Steps
Didn't add tests or changed the version, leaving that up to you :)