### PR TITLE
Overflow bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
         background: blue;
         color: white;
         border-radius: 3px;
-        overflow: auto;
       }
 
       .inner-wrapper {
@@ -36,6 +35,21 @@
             <p>My first paragraph.</p>
             <label>Text Block:</label>
             <textarea></textarea>
+
+            <pre style="background: black;">
+              1
+              2
+              3
+              4
+              5
+              6
+              7
+              8
+              9
+              10
+              11
+              12
+            </pre>
           </div>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slide-element",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slide-element",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slide-element",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A tiny, accessible, Promise-based, jQuery-reminiscent library for hiding and showing elements in a sliding fashion.",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -69,13 +69,11 @@ it("opens element", (done) => {
       [
         expect.objectContaining({
           height: "0px",
-          overflow: "hidden",
           paddingBottom: "0px",
           paddingTop: "0px",
         }),
         expect.objectContaining({
           height: "100px",
-          overflow: "hidden",
           paddingBottom: "",
           paddingTop: "",
         }),
@@ -99,13 +97,11 @@ it("closes element", (done) => {
       [
         expect.objectContaining({
           height: "100px",
-          overflow: "hidden",
           paddingBottom: "",
           paddingTop: "",
         }),
         expect.objectContaining({
           height: "0px",
-          overflow: "hidden",
           paddingBottom: "0px",
           paddingTop: "0px",
         }),
@@ -231,7 +227,7 @@ describe("custom options", () => {
   });
 });
 
-describe("accessibility settigns", () => {
+describe("accessibility settings", () => {
   it("disables animation when user prefers reduced motion", (done) => {
     const { element } = withMockAnimation(screen.getByTestId("content"));
 
@@ -269,6 +265,30 @@ describe("accessibility settigns", () => {
 
     up(element).then(() => {
       expect(element.getAttribute("aria-expanded")).toEqual("false");
+      done();
+    });
+  });
+});
+
+describe("overflow handling", () => {
+  it("temporarily sets overflow to auto", (done) => {
+    document.body.innerHTML = `<div data-testid="content" style="display: none;">Content!</div>`;
+    const { element } = withMockAnimation(screen.getByTestId("content"));
+
+    expect(element.style.overflow).toEqual("");
+
+    element.animate = () => {
+      return {
+        play() {},
+        finished: new Promise((resolve) => {
+          expect(element.style.overflow).toEqual("auto");
+          resolve();
+        }),
+      };
+    };
+
+    down(element).then(() => {
+      expect(element.style.overflow).toEqual("");
       done();
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ let SlideController = (
   let setData = (value: string) => (element.dataset.se = value);
   let getHeight = (inPixels = false) => getRawHeight(element, inPixels);
   let getComputed = () => window.getComputedStyle(element);
+  let setOverflow = (set: boolean) =>
+    (element.style.overflow = set ? "auto" : "");
 
   let mergedOptions: Options = Object.assign({}, defaultOptions, options);
   let openDisplayValue = mergedOptions.display as string;
@@ -43,7 +45,6 @@ let SlideController = (
       height,
       paddingTop: "0px",
       paddingBottom: "0px",
-      overflow: "hidden",
     }));
 
     let { paddingTop, paddingBottom } = getComputed();
@@ -88,7 +89,11 @@ let SlideController = (
       // Make it visible before we animate it open.
       if (willOpen) setDisplay(openDisplayValue);
 
+      setOverflow(true);
+
       await createAnimation(willOpen, currentHeight).finished;
+
+      setOverflow(false);
 
       if (!willOpen) setDisplay(closedDisplayValue);
 


### PR DESCRIPTION
# Description of Proposed Changes
When particular items (like `pre` tags) were contained within an element sliding open & closed, Safari allowed the contents to bleed out of the container on animation. 

This is fixed by explicitly setting an `overflow` property when an animation is executed. 