### PR TITLE
Fix accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,17 @@ options | `object` | Options to customize sliding animation.
 
 This library will respect the `prefers-reduced-motion` setting on a user's machine. When it's set to `reduce`, the sliding animation will be forced to a duration of `0`, making the respective elements open and close instantly.
 
-Additionally, `aria-expanded` attribute will be set after an animation is complete. The attribute will _not_ be automatically set on initial page load, however. So, you should set it yourself to match what the initial state of the element will be.
+Additionally, it's highly recommended that you toggle the `aria-expanded` attribute on any element (like a button) that's responsible for triggering an animation. This can be done by adding a single line of code that fires afters an animation is complete:
 
+```javascript
+document.getElementById('someButton').addEventListener('click', (e) => {
+    toggle(document.getElementById('thing2')).then((opened) => {
+
+      <!-- Set the appropriate `aria-expanded` value based on the state of the container. -->
+      e.target.setAttribute("aria-expanded", opened);
+    });
+  });
+```
 ## Show Off Your Use Case
 
 I love to see examples of how you're using the stuff I build. If you're comfortable, please [send it my way](http://macarthur.me/contact)!

--- a/index.html
+++ b/index.html
@@ -90,12 +90,14 @@
           duration: 200,
         }).then(opened => {
           console.log("Is open:", opened);
+          e.target.setAttribute("aria-expanded", opened);
         });
       });
 
       document.getElementById('slideThing2').addEventListener('click', (e) => {
         toggle(document.getElementById('thing2')).then((opened) => {
           console.log("Is open:", opened);
+          e.target.setAttribute("aria-expanded", opened);
         });
       });
     </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slide-element",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A tiny, accessible, Promise-based, jQuery-reminiscent library for hiding and showing elements in a sliding fashion.",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -246,28 +246,6 @@ describe("accessibility settings", () => {
       done();
     });
   });
-
-  it("sets aria-expanded correctly when open", (done) => {
-    document.body.innerHTML = `<div data-testid="content" style="display: none;">Content!</div>`;
-    const { element } = withMockAnimation(screen.getByTestId("content"));
-
-    mockHeightOnce([0, 100, 0]);
-
-    down(element).then(() => {
-      expect(element.getAttribute("aria-expanded")).toEqual("true");
-      done();
-    });
-  });
-
-  it("sets aria-expanded correctly when closed", (done) => {
-    document.body.innerHTML = `<div data-testid="content" style="height: 100px">Content!</div>`;
-    const { element } = withMockAnimation(screen.getByTestId("content"));
-
-    up(element).then(() => {
-      expect(element.getAttribute("aria-expanded")).toEqual("false");
-      done();
-    });
-  });
 });
 
 describe("overflow handling", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,6 @@ let SlideController = (
 
       if (!willOpen) setDisplay(closedDisplayValue);
 
-      element.setAttribute("aria-expanded", willOpen as unknown as string);
-
       delete element.dataset.se;
     });
 


### PR DESCRIPTION
# Description of Proposed Changes
No longer sets `aria-expanded` on the element that's sliding open or closed, since it's supposed to be used on the element that triggered the animation: 

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded

# Related Issue (if applicable)
#24 
