### PR TITLE
temporarily set overflow to hidden instead of auto

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -240,7 +240,7 @@ describe("accessibility settings", () => {
 });
 
 describe("overflow handling", () => {
-  it("temporarily sets overflow to auto", (done) => {
+  it("temporarily sets overflow to hidden", (done) => {
     document.body.innerHTML = `<div data-testid="content" style="display: none;">Content!</div>`;
     const { element } = withMockAnimation(screen.getByTestId("content"));
 
@@ -249,7 +249,7 @@ describe("overflow handling", () => {
     element.animate = () => {
       return {
         finished: new Promise((resolve) => {
-          expect(element.style.overflow).toEqual("auto");
+          expect(element.style.overflow).toEqual("hidden");
           resolve();
         }),
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ let SlideController = (
   let getHeight = () => element.clientHeight + "px";
   let getComputed = () => window.getComputedStyle(element);
   let setOverflow = (set: boolean) =>
-    (element.style.overflow = set ? "auto" : "");
+    (element.style.overflow = set ? "hidden" : "");
   let getAnimations = () => element.getAnimations();
 
   let mergedOptions: Options = Object.assign({}, defaultOptions, options);


### PR DESCRIPTION
# Description of Proposed Changes
As discussed in https://github.com/alexmacarthur/slide-element/issues/29 setting the overflow value to "auto" during the animation causes a scrollbar to appear for the duration of the animation which seems to be counter to this library's goal.

# Related Issue (if applicable)
https://github.com/alexmacarthur/slide-element/issues/29

# Testing Steps
Animate a large element with this library at a slow speed and you will see a scrollbar appear on the edge of the element as it animates. After applying this patch that scrollbar should no longer appear.